### PR TITLE
Add chat app readme

### DIFF
--- a/chat-app/README.md
+++ b/chat-app/README.md
@@ -1,0 +1,34 @@
+# Write and Deploy Chat Application Frontend and Backend
+
+### Link to the coursework
+
+https://sdc.codeyourfuture.io/decomposition/sprints/2/prep/
+
+You must complete and deploy a chat application. You have two weeks to complete this.
+
+It must support at least the following requirements:
+* As a user, I can send add a message to the chat.
+* As a user, when I open the chat I see the messages that have been sent by any user.
+* As a user, when someone sends a message, it gets added to what I see.
+
+It must also support at least one additional feature.
+
+### Why are we doing this?
+
+Learning about deploying multiple pieces of software that interact.
+
+Designing and implementing working software that users can use.
+
+Exploring and understanding different ways of sending information between a client and server.
+
+### Maximum time in hours
+
+16
+
+### How to submit
+
+* Fork the Module-Decomposition repository
+* Develop and deploy your chat app
+* Create a pull request back into the original Module-Decomposition repo, including:
+    * A link to the deployed frontend on the CYF hosting environment
+    * A link to the deployed backend on the CYF hosting environment


### PR DESCRIPTION
Add a directory to complete the chat-app inside.

The trainee will now need to fork this repo, and work on this task, then make a PR to submit.

* They will need to take an extra step to configure netlify to work using chat-app as a base directory - I have not added explicit guidance on this anywhere.
* I have not added frontend/backend directories, should we let them figure that out or would it be worth having them in the template?

The issue ticket has been updated already